### PR TITLE
feat: Implement interactive placement of blockers

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ from textual.app import App, ComposeResult
 from textual.widgets import Header, Footer, Input, Static, Select
 from textual.containers import Vertical
 from textual.reactive import reactive
+from textual.events import Click
 from betza_parser import BetzaParser
 
 
@@ -19,6 +20,7 @@ class BetzaChessApp(App):
 
     board_size = reactive(DEFAULT_BOARD_SIZE)
     moves = reactive([])
+    blockers = reactive(set())
 
     def compose(self) -> ComposeResult:
         yield Header()
@@ -51,10 +53,39 @@ class BetzaChessApp(App):
     def on_select_changed(self, event: Select.Changed) -> None:
         self.board_size = event.value
 
+    def on_click(self, event: Click) -> None:
+        if event.button != 1:
+            return
+        if self.query_one("#board").id != "board":
+            return
+
+        center = self.board_size // 2
+        # The board characters are space-separated
+        col = event.x // 2
+        row = event.y
+
+        blocker_x = col - center
+        blocker_y = center - row
+
+        if blocker_x == 0 and blocker_y == 0:
+            return
+
+        blocker_coord = (blocker_x, blocker_y)
+        new_blockers = self.blockers.copy()
+        if blocker_coord in new_blockers:
+            new_blockers.remove(blocker_coord)
+        else:
+            new_blockers.add(blocker_coord)
+        self.blockers = new_blockers
+
     def watch_board_size(self, new_size: int) -> None:
+        self.blockers = set()
         self.query_one("#board").update(self.render_board())
 
     def watch_moves(self, new_moves: list) -> None:
+        self.query_one("#board").update(self.render_board())
+
+    def watch_blockers(self, new_blockers: set) -> None:
         self.query_one("#board").update(self.render_board())
 
     def render_board(self) -> str:
@@ -64,33 +95,12 @@ class BetzaChessApp(App):
         board = [["." for _ in range(board_size)] for _ in range(board_size)]
         board[center][center] = "🧚"
 
-        hurdles = set()
-        special_moves = [m for m in moves if m[3] is not None or m[4] != "normal"]
-
-        if special_moves:
-            hopper_moves = [m for m in special_moves if m[3] is not None]
-            if hopper_moves:
-                unique_directions_set = {(sign(x), sign(y)) for x, y, _, _, _, _ in hopper_moves}
-                unique_directions = sorted(list(unique_directions_set))
-                if len(unique_directions) == 4 and any(
-                    d[0] == 0 or d[1] == 0 or d[0] == d[1] for d in unique_directions
-                ):
-                    unique_directions.pop()
-                for dx, dy in unique_directions:
-                    hurdles.add((dx * 2, dy * 2))
-
-            nj_leapers = [m for m in special_moves if m[4] != "normal"]
-            if nj_leapers:
-                hurdles.update([(0, 1), (-1, 0)])
-
-            # --- FIX: Render hurdles to the board FIRST ---
-            for hx, hy in hurdles:
-                if 0 <= center - hy < board_size and 0 <= center + hx < board_size:
-                    board[center - hy][center + hx] = "♙"
+        for bx, by in self.blockers:
+            if 0 <= center - by < board_size and 0 <= center + bx < board_size:
+                board[center - by][center + bx] = "♙"
 
         move_map = {"move_capture": "X", "move": "m", "capture": "x"}
 
-        # --- FIX: Render moves SECOND, allowing them to overwrite hurdles if necessary ---
         for x, y, move_type, hop_type, jump_type, atom in moves:
             display_y, display_x = center - y, center + x
             if not (0 <= display_y < board_size and 0 <= display_x < board_size):
@@ -104,7 +114,7 @@ class BetzaChessApp(App):
                 elif abs(y) > abs(x):
                     block_y = sign(y)
 
-                if (block_x, block_y) in hurdles:
+                if (block_x, block_y) in self.blockers:
                     is_valid = False
 
             elif jump_type == "jumping":
@@ -115,27 +125,26 @@ class BetzaChessApp(App):
                 elif abs(y) > abs(x):
                     block_y = sign(y)
 
-                if (block_x, block_y) in hurdles:
+                if (block_x, block_y) in self.blockers:
                     is_valid = True
 
             elif hop_type is not None:
                 is_valid = False
                 dx, dy = sign(x), sign(y)
                 path = [(i * dx, i * dy) for i in range(1, max(abs(x), abs(y)))]
-                hurdles_on_path = [p for p in path if p in hurdles]
-                if len(hurdles_on_path) == 1:
+                blockers_on_path = [p for p in path if p in self.blockers]
+                if len(blockers_on_path) == 1:
                     if hop_type == "p":
                         is_valid = True
                     elif hop_type == "g":
-                        hurdle_pos = hurdles_on_path[0]
-                        if x == hurdle_pos[0] + dx and y == hurdle_pos[1] + dy:
+                        blocker_pos = blockers_on_path[0]
+                        if x == blocker_pos[0] + dx and y == blocker_pos[1] + dy:
                             is_valid = True
 
             if is_valid:
-                # This will now draw a move marker even if a hurdle was there before
-                is_on_hurdle = (x,y) in hurdles
+                is_on_blocker = (x, y) in self.blockers
                 char = move_map.get(move_type, "?")
-                if is_on_hurdle:
+                if is_on_blocker:
                     if char == "m":
                         char = "M"
                     elif char == "x":
@@ -144,7 +153,6 @@ class BetzaChessApp(App):
                         char = "#"
                 board[display_y][display_x] = char
 
-        # --- FIX: Adjust spacing for wide characters ---
         rendered_rows = []
         for row in board:
             row_str = " ".join(row)

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,12 +17,13 @@ const COLORS = {
   move: '#FFD700',
   capture: '#DC143C',
   hop: '#32CD32',
-  hurdle: '#606060',
+  blocker: '#606060',
 };
 
 const sign = (n: number): number => Math.sign(n);
+const blockers = new Set<string>();
 
-function renderBoard(moves: Move[]) {
+function renderBoard(moves: Move[], blockers: Set<string>) {
   const svg = document.createElementNS(SVG_NS, 'svg');
   svg.setAttribute('width', '100%');
   svg.setAttribute('height', '100%');
@@ -30,6 +31,8 @@ function renderBoard(moves: Move[]) {
     'viewBox',
     `0 0 ${boardSize * CELL_SIZE} ${boardSize * CELL_SIZE}`
   );
+
+  const center = Math.floor(boardSize / 2);
 
   for (let r = 0; r < boardSize; r++) {
     for (let c = 0; c < boardSize; c++) {
@@ -43,62 +46,51 @@ function renderBoard(moves: Move[]) {
     }
   }
 
-  const center = Math.floor(boardSize / 2);
+  svg.addEventListener('click', (event) => {
+    const svgPoint = svg.createSVGPoint();
+    svgPoint.x = event.clientX;
+    svgPoint.y = event.clientY;
+    const { x, y } = svgPoint.matrixTransform(
+      (svg.getScreenCTM() as SVGMatrix).inverse()
+    );
 
-  const hurdles = new Set<string>();
-  const specialMoves = moves.filter(
-    (m) => m.hopType !== null || m.jumpType !== 'normal'
-  );
+    const c = Math.floor(x / CELL_SIZE);
+    const r = Math.floor(y / CELL_SIZE);
 
-  if (specialMoves.length > 0) {
-    const hopperMoves = specialMoves.filter((m) => m.hopType !== null);
-    if (hopperMoves.length > 0) {
-      const uniqueDirections = [
-        ...new Set(hopperMoves.map((m) => `${sign(m.x)},${sign(m.y)}`)),
-      ];
-      if (uniqueDirections.length === 4) {
-        const isRookLike = ['0,1', '0,-1', '1,0', '-1,0'].every((d) =>
-          uniqueDirections.includes(d)
-        );
-        const isBishopLike = ['1,1', '1,-1', '-1,1', '-1,-1'].every((d) =>
-          uniqueDirections.includes(d)
-        );
-        if (isRookLike || isBishopLike) uniqueDirections.pop();
-      }
-      uniqueDirections.forEach((dir) =>
-        hurdles.add(
-          `${dir.split(',').map(Number)[0] * 2},${dir.split(',').map(Number)[1] * 2}`
-        )
-      );
+    const blockerX = c - center;
+    const blockerY = center - r;
+
+    if (blockerX === 0 && blockerY === 0) return;
+
+    const blockerCoord = `${blockerX},${blockerY}`;
+    if (blockers.has(blockerCoord)) {
+      blockers.delete(blockerCoord);
+    } else {
+      blockers.add(blockerCoord);
     }
+    updateBoard();
+  });
 
-    const njLeapers = specialMoves.filter((m) => m.jumpType !== 'normal');
-    if (njLeapers.length > 0) {
-      ['0,1', '-1,0'].forEach((dir) => hurdles.add(dir));
-    }
-
-    hurdles.forEach((h) => {
-      const [hx, hy] = h.split(',').map(Number);
-      const cx = (center + hx) * CELL_SIZE + CELL_SIZE / 2;
-      const cy = (center - hy) * CELL_SIZE + CELL_SIZE / 2;
-      const hurdle = document.createElementNS(SVG_NS, 'text');
-      hurdle.textContent = '♙';
-      hurdle.setAttribute('x', String(cx));
-      hurdle.setAttribute('y', String(cy));
-      hurdle.setAttribute('font-size', String(CELL_SIZE * 0.7));
-      hurdle.setAttribute('text-anchor', 'middle');
-      hurdle.setAttribute('dominant-baseline', 'central');
-      hurdle.setAttribute('fill', COLORS.hurdle);
-      hurdle.setAttribute('opacity', '0.8');
-      svg.appendChild(hurdle);
-    });
-  }
+  blockers.forEach((b) => {
+    const [bx, by] = b.split(',').map(Number);
+    const cx = (center + bx) * CELL_SIZE + CELL_SIZE / 2;
+    const cy = (center - by) * CELL_SIZE + CELL_SIZE / 2;
+    const blocker = document.createElementNS(SVG_NS, 'text');
+    blocker.textContent = '♙';
+    blocker.setAttribute('x', String(cx));
+    blocker.setAttribute('y', String(cy));
+    blocker.setAttribute('font-size', String(CELL_SIZE * 0.7));
+    blocker.setAttribute('text-anchor', 'middle');
+    blocker.setAttribute('dominant-baseline', 'central');
+    blocker.setAttribute('fill', COLORS.blocker);
+    blocker.setAttribute('opacity', '0.8');
+    svg.appendChild(blocker);
+  });
 
   moves.forEach((move) => {
     const { x, y, moveType, hopType, jumpType } = move;
     const cx = (center + x) * CELL_SIZE + CELL_SIZE / 2;
     const cy = (center - y) * CELL_SIZE + CELL_SIZE / 2;
-    let color = '';
     let isValid = true;
 
     if (jumpType === 'non-jumping') {
@@ -106,14 +98,14 @@ function renderBoard(moves: Move[]) {
         blockY = 0;
       if (Math.abs(x) > Math.abs(y)) blockX = sign(x);
       else if (Math.abs(y) > Math.abs(x)) blockY = sign(y);
-      if (hurdles.has(`${blockX},${blockY}`)) isValid = false;
+      if (blockers.has(`${blockX},${blockY}`)) isValid = false;
     } else if (jumpType === 'jumping') {
       isValid = false;
       let blockX = 0,
         blockY = 0;
       if (Math.abs(x) > Math.abs(y)) blockX = sign(x);
       else if (Math.abs(y) > Math.abs(x)) blockY = sign(y);
-      if (hurdles.has(`${blockX},${blockY}`)) isValid = true;
+      if (blockers.has(`${blockX},${blockY}`)) isValid = true;
     } else if (hopType) {
       isValid = false;
       const path: string[] = [];
@@ -122,11 +114,11 @@ function renderBoard(moves: Move[]) {
       for (let i = 1; i < Math.max(Math.abs(x), Math.abs(y)); i++) {
         path.push(`${i * dx},${i * dy}`);
       }
-      const hurdlesOnPath = path.filter((p) => hurdles.has(p));
-      if (hurdlesOnPath.length === 1) {
+      const blockersOnPath = path.filter((p) => blockers.has(p));
+      if (blockersOnPath.length === 1) {
         if (hopType === 'p') isValid = true;
         else if (hopType === 'g') {
-          const [hx, hy] = hurdlesOnPath[0].split(',').map(Number);
+          const [hx, hy] = blockersOnPath[0].split(',').map(Number);
           if (x === hx + dx && y === hy + dy) isValid = true;
         }
       }
@@ -211,15 +203,16 @@ function renderBoard(moves: Move[]) {
   boardContainer.appendChild(svg);
 }
 
-renderBoard([]);
-
 function updateBoard() {
   const moves = parser.parse(inputEl.value);
-  renderBoard(moves);
+  renderBoard(moves, blockers);
 }
+
+renderBoard([], blockers);
 
 inputEl.addEventListener('input', updateBoard);
 boardSizeSelect.addEventListener('change', () => {
   boardSize = Number(boardSizeSelect.value);
+  blockers.clear();
   updateBoard();
 });


### PR DESCRIPTION
This commit refactors the Betza visualizer to allow for interactive placement of blockers on the board, replacing the previous hardcoded hurdle logic.

Key changes:
- Removed the automatic generation of 'hurdles' based on piece notation in both the web (TypeScript) and terminal (Python) versions.
- Introduced a 'blockers' state, managed as a Set of coordinates, in both implementations.
- Implemented click handlers for both the SVG-based web UI and the Textual-based terminal UI to allow users to add or remove blockers by clicking on board squares.
- Updated the move validation logic to use the user-managed 'blockers' set, correctly affecting jumping, non-jumping, and hopping pieces.
- Ensured that changing the board size clears the existing blockers.

This change provides users with a more flexible and interactive way to visualize how piece movements are affected by obstacles on the board, fulfilling the requirements of the issue.