### PR TITLE
Fix(web): Constrain slider moves to board boundaries

### DIFF
--- a/betza_parser.py
+++ b/betza_parser.py
@@ -30,7 +30,7 @@ class BetzaParser:
         }
         self.infinity_cap = 12
 
-    def parse(self, notation: str) -> List[Tuple[int, int, str, Optional[str], str, str]]:
+    def parse(self, notation: str, board_size: Optional[int] = None) -> List[Tuple[int, int, str, Optional[str], str, str]]:
         """
         Parses notation. Returns a list of 6-element tuples:
         (x, y, move_type, hop_type, jump_type, base_atom)
@@ -81,7 +81,12 @@ class BetzaParser:
             elif "j" in current_mods:
                 jump_type = "jumping"
 
-            max_steps = 1 if count_str == "" else self.infinity_cap if count_str == "0" else int(count_str)
+            if count_str == "0":
+                max_steps = board_size // 2 if board_size is not None else self.infinity_cap
+            elif count_str == "":
+                max_steps = 1
+            else:
+                max_steps = int(count_str)
             x_atom, y_atom = self.atoms[atom]
             base_directions = self._get_directions(x_atom, y_atom)
             allowed_directions = self._filter_directions(

--- a/main.py
+++ b/main.py
@@ -106,11 +106,13 @@ class BetzaChessApp(App):
         if isinstance(event.item, PieceListItem):
             input_widget = self.query_one("#betza_input")
             input_widget.value = event.item.piece_betza
-            self.moves = self.parser.parse(input_widget.value)
+            self.moves = self.parser.parse(
+                input_widget.value, board_size=self.board_size
+            )
             self.blockers = set()
 
     def on_input_changed(self, event: Input.Changed) -> None:
-        self.moves = self.parser.parse(event.value)
+        self.moves = self.parser.parse(event.value, board_size=self.board_size)
 
     def on_select_changed(self, event: Select.Changed) -> None:
         if event.select.id == "board_size_select":

--- a/src/betza_parser.ts
+++ b/src/betza_parser.ts
@@ -24,7 +24,7 @@ export class BetzaParser {
   ]);
   public readonly infinityCap = 12;
 
-  public parse(notation: string): Move[] {
+  public parse(notation: string, boardSize?: number): Move[] {
     const moves: Move[] = [];
     const tokenWorklist: string[] = notation.match(/[a-z]+|[A-Z]\d*/g) || [];
     let currentMods = '';
@@ -76,12 +76,14 @@ export class BetzaParser {
       if (currentMods.includes('n')) jumpType = 'non-jumping';
       else if (currentMods.includes('j')) jumpType = 'jumping';
 
-      const maxSteps =
-        countStr === ''
-          ? 1
-          : countStr === '0'
-            ? this.infinityCap
-            : parseInt(countStr);
+      let maxSteps: number;
+      if (countStr === '0') {
+        maxSteps = boardSize ? Math.floor(boardSize / 2) : this.infinityCap;
+      } else if (countStr === '') {
+        maxSteps = 1;
+      } else {
+        maxSteps = parseInt(countStr);
+      }
       const { x: atomX, y: atomY } = this.atoms.get(atom)!;
 
       const baseDirections = this._getDirections(atomX, atomY);

--- a/src/main.ts
+++ b/src/main.ts
@@ -250,7 +250,7 @@ function renderBoard(moves: Move[], blockers: Set<string>) {
 }
 
 function updateBoard() {
-  const moves = parser.parse(inputEl.value);
+  const moves = parser.parse(inputEl.value, boardSize);
   renderBoard(moves, blockers);
 }
 


### PR DESCRIPTION
The Betza notation parser was generating moves for slider pieces (like Rooks and Queens) that extended beyond the board's boundaries. This was because it used a hardcoded `infinity_cap` value instead of considering the actual board size.

This commit fixes the issue by:
1.  Modifying the `parse` method in both `betza_parser.py` and `src/betza_parser.ts` to accept an optional `board_size` parameter.
2.  When the move count is `0` (indicating a slider), the `max_steps` is now calculated as `board_size // 2`, which is the correct maximum distance from the center of the board.
3.  Updating the call sites in `main.py` and `src/main.ts` to pass the current board size to the `parse` method.

This change ensures that the move generation logic is consistent between the Python and TypeScript implementations and that the web application no longer displays moves that go off the board.