### PR TITLE
Fix: Prevent rendering of off-board moves in web app

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -92,6 +92,19 @@ function renderBoard(moves: Move[], blockers: Set<string>) {
 
   moves.forEach((move) => {
     const { x, y, moveType, hopType, jumpType } = move;
+
+    // Check if the move is within the board boundaries
+    const boardX = center + x;
+    const boardY = center - y;
+    if (
+      boardX < 0 ||
+      boardX >= boardSize ||
+      boardY < 0 ||
+      boardY >= boardSize
+    ) {
+      return; // Skip rendering for off-board moves
+    }
+
     const cx = (center + x) * CELL_SIZE + CELL_SIZE / 2;
     const cy = (center - y) * CELL_SIZE + CELL_SIZE / 2;
     let isValid: boolean;

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -101,3 +101,24 @@ def test_leaper_unblocked(page: Page):
 
     # The knight should not be blocked, so there should still be 8 moves.
     expect(page.locator("#board-container circle")).to_have_count(8)
+
+
+@pytest.mark.e2e
+def test_slider_moves_are_on_board(page: Page):
+    """
+    Tests that a slider piece (e.g., Nightrider N0) does not render moves
+    that are off the board.
+    """
+    page.goto("http://localhost:8080")
+
+    # Select a small board size to make it easy to have off-board moves
+    page.locator("#boardSizeSelect").select_option("5")
+
+    # Set the input to N0 (Nightrider)
+    page.locator("#betzaInput").fill("N0")
+
+    # On a 5x5 board, a Nightrider from the center has 8 on-board moves.
+    # The parser will generate more moves that are off-board.
+    # We expect that only the 8 on-board moves are rendered.
+    # Nightrider moves are jumping, so they are rendered as circles.
+    expect(page.locator("#board-container circle")).to_have_count(8)


### PR DESCRIPTION
The web application was rendering moves for slider pieces outside the visible board area. This was because the rendering logic in `src/main.ts` did not check if a move's coordinates were within the board's boundaries before creating the SVG elements for it.

This change adds a boundary check to the `renderBoard` function in `src/main.ts`. The check ensures that only moves that land on a valid square on the board are rendered.

The Python TUI implementation was also inspected and was found to already have the correct boundary check, so no changes were needed there.

A new E2E test has been added to `tests/test_web_app.py` to verify that off-board moves are not rendered for slider pieces. This test uses a small board size and a Nightrider (`N0`) to confirm that only the on-board moves are displayed.