### PR TITLE
feat: Add support for NN (Nightrider) shorthand

### DIFF
--- a/betza_parser.py
+++ b/betza_parser.py
@@ -51,6 +51,12 @@ class BetzaParser:
             match = re.match(r"([A-Z])(\d*)", token)
             letter, suffix = match.groups()
 
+            # Nightrider shorthand: 'NN' -> 'N0'
+            if suffix == "" and token_worklist and token_worklist[0] == letter:
+                token_worklist.pop(0)
+                token_worklist.insert(0, f"{letter}0")
+                continue
+
             if letter in self.compound_aliases:
                 expansion = self.compound_aliases[letter]
                 if suffix:

--- a/src/betza_parser.ts
+++ b/src/betza_parser.ts
@@ -39,6 +39,13 @@ export class BetzaParser {
       if (!match) continue;
       const [, letter, suffix] = match;
 
+      // Nightrider shorthand: 'NN' -> treat as rider 'N0'
+      if (suffix === '' && tokenWorklist[0] === letter) {
+        tokenWorklist.shift(); // consume the second 'N'
+        tokenWorklist.unshift(`${letter}0`); // push rider form
+        continue;
+      }
+
       if (this.compoundAliases.has(letter)) {
         let expansion = this.compoundAliases.get(letter)!;
         if (suffix) {

--- a/tests/betza_parser.test.ts
+++ b/tests/betza_parser.test.ts
@@ -120,6 +120,14 @@ describe('BetzaParser', () => {
             const moves = parser.parse('M');
             expect(moves.length).toBe(12);
         });
+
+        it('should parse a Nightrider shorthand (NN)', () => {
+            const moves = parser.parse('NN');
+            expect(moves.length).toBe(8 * parser.infinityCap);
+            const moveCoords = toCoordSet(moves);
+            expect(moveCoords).toContain('4,2');
+            expect(moveCoords).toContain('-4,-2');
+        });
     });
 
     describe('Advanced Betza Modifier Rules', () => {

--- a/tests/test_betza_parser.py
+++ b/tests/test_betza_parser.py
@@ -99,6 +99,14 @@ class TestFairyStockfishPieces(unittest.TestCase):
         moves = self.parser.parse("M")
         self.assertEqual(len(moves), 12)
 
+    def test_nightrider_shorthand_NN(self):
+        """Tests that 'NN' is parsed as a Nightrider (N0)."""
+        moves = self.parser.parse("NN")
+        move_coords = {m[:2] for m in moves}
+        self.assertEqual(len(moves), 8 * self.parser.infinity_cap)
+        self.assertIn((4, 2), move_coords)
+        self.assertIn((-4, -2), move_coords)
+
 
 class TestAdvancedModifiers(unittest.TestCase):
     """Tests for nuanced modifier rules like quadrants and doubled letters."""


### PR DESCRIPTION
This change implements the "NN" shorthand for the Nightrider piece in the Betza notation parser. Previously, "NN" was parsed as two separate Knight moves. Now, it is correctly interpreted as a single rider piece, equivalent to "N0".

- The change is applied to both the Python and TypeScript parsers to maintain feature parity.
- Unit tests have been added to both test suites to verify the new functionality.