### PR TITLE
Fix: Prevent placing blockers out of bounds

### DIFF
--- a/main.py
+++ b/main.py
@@ -131,6 +131,9 @@ class BetzaChessApp(App):
         col = (event.x - 1) // 2
         row = event.y - 2
 
+        if not (0 <= col < self.board_size and 0 <= row < self.board_size):
+            return
+
         blocker_x = col - center
         blocker_y = center - row
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,15 +50,15 @@ function renderBoard(moves: Move[], blockers: Set<string>) {
   }
 
   svg.addEventListener('click', (event) => {
-    const svgPoint = svg.createSVGPoint();
-    svgPoint.x = event.clientX;
-    svgPoint.y = event.clientY;
-    const { x, y } = svgPoint.matrixTransform(
-      (svg.getScreenCTM() as SVGMatrix).inverse()
-    );
+    const x = event.offsetX;
+    const y = event.offsetY;
 
     const c = Math.floor(x / CELL_SIZE);
     const r = Math.floor(y / CELL_SIZE);
+
+    if (c < 0 || c >= boardSize || r < 0 || r >= boardSize) {
+      return;
+    }
 
     const blockerX = c - center;
     const blockerY = center - r;


### PR DESCRIPTION
This commit fixes a bug where users could place blockers outside the chessboard in both the web and TUI applications.

The fix introduces a bounds check in the click handlers for both the TypeScript (`src/main.ts`) and Python (`main.py`) implementations. It also corrects the coordinate calculation logic in the web application to use `event.offsetX/Y` instead of a faulty `getScreenCTM()` transformation, ensuring that click locations are calculated correctly relative to the board.

Parity is maintained between both versions of the application.