### PR TITLE
Fix modifier application for compound Betza pieces

### DIFF
--- a/betza_parser.py
+++ b/betza_parser.py
@@ -62,8 +62,22 @@ class BetzaParser:
                 expansion = self.compound_aliases[letter]
                 if suffix:
                     expansion = re.sub(r"([A-Z])\d*", rf"\g<1>{suffix}", expansion)
+
                 new_tokens = re.findall(r"[A-Z]\d*", expansion)
+
+                # If there are current modifiers, they need to be applied to each component
+                # of the expanded alias. We do this by inserting them back into the token stream.
+                if current_mods:
+                    prefixed_tokens = []
+                    for t in new_tokens:
+                        prefixed_tokens.append(current_mods)
+                        prefixed_tokens.append(t)
+                    new_tokens = prefixed_tokens
+
                 token_worklist[0:0] = new_tokens
+
+                # The modifiers have been "distributed" to the sub-components, so we can clear them.
+                current_mods = ""
                 continue
 
             if letter not in self.atoms:

--- a/src/betza_parser.ts
+++ b/src/betza_parser.ts
@@ -52,8 +52,22 @@ export class BetzaParser {
         if (suffix) {
           expansion = expansion.replace(/([A-Z])\d*/g, `$1${suffix}`);
         }
-        const newTokens = expansion.match(/[A-Z]\d*/g) || [];
+        let newTokens: string[] = expansion.match(/[A-Z]\d*/g) || [];
+
+        // If there are current modifiers, they need to be applied to each component
+        // of the expanded alias. We do this by inserting them back into the token stream.
+        if (currentMods) {
+          const prefixedTokens: string[] = [];
+          for (const t of newTokens) {
+            prefixedTokens.push(currentMods, t);
+          }
+          newTokens = prefixedTokens;
+        }
+
         tokenWorklist.unshift(...newTokens);
+
+        // The modifiers have been "distributed" to the sub-components, so we can clear them.
+        currentMods = '';
         continue;
       }
 


### PR DESCRIPTION
This commit fixes a bug in the Betza notation parser where modifiers were not being correctly applied to all components of a compound piece.

Previously, if a modifier was applied to a compound piece alias (e.g., `rlbK`), the modifier would only be applied to the first component of the expansion (`W1` from `W1F1`) and not subsequent components (`F1`).

The fix ensures that when a compound alias is expanded, the active modifiers are prepended to each component of the expansion in the token stream. This guarantees that the modifiers are correctly applied to all parts of the compound piece.

This change affects both the Python and TypeScript implementations to maintain parity.