### PR TITLE
feat(web): Add support for loading variants from .ini files

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,11 @@
     <link rel="stylesheet" href="/style.css">
 </head>
 <body>
-    <h1>Betza Notation Visualizer</h1>
+    <div class="title-container">
+        <h1>Betza Notation Visualizer</h1>
+        <button id="loadVariantsBtn">Load Variants</button>
+        <input type="file" id="variantsFileInput" style="display: none;" accept=".ini">
+    </div>
     <div id="grid-container">
         <input type="text" id="betzaInput" placeholder="Enter Betza string (e.g., pR0, BN, Q)">
         <select id="boardSizeSelect">

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "format": "prettier --write \"src/**/*.ts\"",
     "clean": "rm -rf dist && find tests -name '*.js' -delete && find src -name '*.js' -delete",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
-    "build": "yarn clean && ./node_modules/typescript/bin/tsc && cp index.html style.css piece_catalog.json dist/"
+    "build": "yarn clean && ./node_modules/typescript/bin/tsc && cp index.html style.css fsf_built_in_variants_catalog.json dist/"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { BetzaParser } from './betza_parser.js';
-import { Move } from './types.js';
+import { VariantIniParser } from './variant_ini_parser.js';
+import { Move, Piece } from './types.js';
 import {
   CELL_SIZE,
   SVG_NS,
@@ -16,6 +17,12 @@ const boardSizeSelect = document.getElementById(
 const variantSelect = document.getElementById(
   'variant-select'
 ) as HTMLSelectElement;
+const loadVariantsBtn = document.getElementById(
+  'loadVariantsBtn'
+) as HTMLButtonElement;
+const variantsFileInput = document.getElementById(
+  'variantsFileInput'
+) as HTMLInputElement;
 
 let boardSize = Number(boardSizeSelect.value);
 
@@ -315,35 +322,33 @@ function renderLegend() {
   legendContainer.appendChild(createLegendItem(hopIcon, 'Hop'));
 }
 
-async function populateVariantFilter() {
-  try {
-    const response = await fetch('/piece_catalog.json');
-    const pieceCatalog: { name: string; variant: string; betza: string }[] =
-      await response.json();
-    const variants = [
-      ...new Set(pieceCatalog.map((p) => p.variant).join(', ').split(', ')),
-    ].sort();
+function populateVariantFilter(
+  pieceCatalog: Piece[]
+) {
+  const variants = [
+    ...new Set(pieceCatalog.map((p) => p.variant).join(', ').split(', ')),
+  ].sort();
 
-    variantSelect.innerHTML = '';
-    const allOption = document.createElement('option');
-    allOption.value = 'All';
-    allOption.textContent = 'All';
-    variantSelect.appendChild(allOption);
+  variantSelect.innerHTML = '';
+  const allOption = document.createElement('option');
+  allOption.value = 'All';
+  allOption.textContent = 'All';
+  variantSelect.appendChild(allOption);
 
-    variants.forEach((variant) => {
-      if (variant) {
-        const option = document.createElement('option');
-        option.value = variant;
-        option.textContent = variant;
-        variantSelect.appendChild(option);
-      }
-    });
-  } catch (error) {
-    console.error('Error populating variant filter:', error);
-  }
+  variants.forEach((variant) => {
+    if (variant) {
+      const option = document.createElement('option');
+      option.value = variant;
+      option.textContent = variant;
+      variantSelect.appendChild(option);
+    }
+  });
 }
 
-async function renderPieceCatalog(filterVariant = 'All') {
+function renderPieceCatalog(
+  pieceCatalog: Piece[],
+  filterVariant = 'All'
+) {
   const catalogContainer = document.getElementById('piece-catalog-container')!;
   const catalogContent =
     document.getElementById('piece-catalog-content') ||
@@ -351,50 +356,52 @@ async function renderPieceCatalog(filterVariant = 'All') {
   catalogContent.id = 'piece-catalog-content';
   catalogContent.innerHTML = '';
 
-  try {
-    const response = await fetch('/piece_catalog.json');
-    const pieceCatalog = await response.json();
+  const filteredPieces =
+    filterVariant === 'All'
+      ? pieceCatalog
+      : pieceCatalog.filter((p: { variant: string }) =>
+          p.variant
+            .split(', ')
+            .map((v) => v.trim())
+            .includes(filterVariant)
+        );
 
-    const filteredPieces =
-      filterVariant === 'All'
-        ? pieceCatalog
-        : pieceCatalog.filter((p: { variant: string }) =>
-            p.variant.split(', ').map(v => v.trim()).includes(filterVariant)
-          );
+  filteredPieces.forEach(
+    (piece: { name: string; variant: string; betza: string }) => {
+      const item = document.createElement('div');
+      item.classList.add('piece-catalog-item');
+      item.dataset.betza = piece.betza;
 
-    filteredPieces.forEach(
-      (piece: { name: string; variant: string; betza: string }) => {
-        const item = document.createElement('div');
-        item.classList.add('piece-catalog-item');
-        item.dataset.betza = piece.betza;
+      const nameEl = document.createElement('div');
+      nameEl.classList.add('name');
+      nameEl.textContent = piece.name;
 
-        const nameEl = document.createElement('div');
-        nameEl.classList.add('name');
-        nameEl.textContent = piece.name;
+      const variantEl = document.createElement('div');
+      variantEl.classList.add('variant');
+      variantEl.textContent = piece.variant;
 
-        const variantEl = document.createElement('div');
-        variantEl.classList.add('variant');
-        variantEl.textContent = piece.variant;
-
-        item.appendChild(nameEl);
-        item.appendChild(variantEl);
-        catalogContent.appendChild(item);
-      }
-    );
-    if (!document.getElementById('piece-catalog-content')) {
-      catalogContainer.appendChild(catalogContent);
+      item.appendChild(nameEl);
+      item.appendChild(variantEl);
+      catalogContent.appendChild(item);
     }
-  } catch (error) {
-    console.error('Error loading piece catalog:', error);
-    catalogContent.textContent = 'Error loading piece catalog.';
+  );
+  if (!document.getElementById('piece-catalog-content')) {
+    catalogContainer.appendChild(catalogContent);
   }
 }
 
 async function initialize() {
+  let pieceCatalog: Piece[] = [];
   renderBoard([], blockers);
   renderLegend();
-  await populateVariantFilter();
-  await renderPieceCatalog();
+  try {
+    const response = await fetch('/fsf_built_in_variants_catalog.json');
+    pieceCatalog = await response.json();
+    populateVariantFilter(pieceCatalog);
+    renderPieceCatalog(pieceCatalog);
+  } catch (error) {
+    console.error('Error loading piece catalog:', error);
+  }
 
   inputEl.addEventListener('input', updateBoard);
   boardSizeSelect.addEventListener('change', () => {
@@ -407,7 +414,35 @@ async function initialize() {
     inputEl.value = '';
     blockers.clear();
     updateBoard();
-    renderPieceCatalog(variantSelect.value);
+    renderPieceCatalog(pieceCatalog, variantSelect.value);
+  });
+
+  loadVariantsBtn.addEventListener('click', () => {
+    variantsFileInput.click();
+  });
+
+  variantsFileInput.addEventListener('change', (event) => {
+    const file = (event.target as HTMLInputElement).files?.[0];
+    if (!file) {
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const content = e.target?.result as string;
+      if (content) {
+        try {
+          const iniParser = new VariantIniParser(content, pieceCatalog);
+          const newPieces = iniParser.parse();
+          pieceCatalog.push(...newPieces);
+          populateVariantFilter(pieceCatalog);
+          renderPieceCatalog(pieceCatalog);
+        } catch (error) {
+          console.error('Error parsing variants.ini file:', error);
+        }
+      }
+    };
+    reader.readAsText(file);
   });
 
   document


### PR DESCRIPTION
This commit introduces the ability for the web application to load user-defined chess variants from `.ini` files.

Key changes include:
- A "Load Variants" button and a file input have been added to the UI.
- The application now fetches the base piece catalog from `fsf_built_in_variants_catalog.json` to ensure consistency with the TUI application and to support variant inheritance.
- The `VariantIniParser` is used to parse the content of the selected `.ini` file.
- The parsed pieces are merged with the existing catalog, and the UI is updated to reflect the new variants.
- The build script has been updated to include the new catalog file in the distribution.