### PR TITLE
Fix incorrect parsing of Betza direction modifiers

### DIFF
--- a/tests/python_unittests/test_betza_parser.py
+++ b/tests/python_unittests/test_betza_parser.py
@@ -134,6 +134,18 @@ class TestAdvancedModifiers(unittest.TestCase):
             {(m['x'], m['y']) for m in moves_ffN},
         )
 
+    def test_half_modifier_fhN(self):
+        """Tests that 'fhN' produces all 4 forward Knight moves."""
+        moves = self.parser.parse("fhN")
+        move_coords = {(m['x'], m['y']) for m in moves}
+        self.assertSetEqual(move_coords, {(-1, 2), (1, 2), (-2, 1), (2, 1)})
+
+    def test_union_of_doubled_modifiers_ffrrN(self):
+        """Tests that 'ffrrN' produces a union of forward and right moves."""
+        moves = self.parser.parse("ffrrN")
+        move_coords = {(m['x'], m['y']) for m in moves}
+        self.assertSetEqual(move_coords, {(-1, 2), (1, 2), (2, 1), (2, -1)})
+
     def test_doubled_modifier_srrC_sideways_camel(self):
         moves = self.parser.parse("srrC")
         move_coords = {(m['x'], m['y']) for m in moves}
@@ -191,6 +203,18 @@ class TestDirectionalShorthand(unittest.TestCase):
 
     def setUp(self):
         self.parser = BetzaParser()
+
+    def test_vertical_modifier_vN_on_hippogonal(self):
+        """Tests that 'vN' produces vertical-only knight moves."""
+        moves = self.parser.parse("vN")
+        move_coords = {(m['x'], m['y']) for m in moves}
+        self.assertSetEqual(move_coords, {(-1, 2), (1, 2), (-1, -2), (1, -2)})
+
+    def test_sideways_modifier_sN_on_hippogonal(self):
+        """Tests that 'sN' produces sideways-only knight moves."""
+        moves = self.parser.parse("sN")
+        move_coords = {(m['x'], m['y']) for m in moves}
+        self.assertSetEqual(move_coords, {(-2, 1), (2, 1), (-2, -1), (2, -1)})
 
     def test_vertical_modifier_vR(self):
         """Tests that 'vR' produces only vertical moves for a Rook."""

--- a/tests/yarn_tests/betza_parser.test.ts
+++ b/tests/yarn_tests/betza_parser.test.ts
@@ -155,6 +155,18 @@ describe('BetzaParser', () => {
             expect(toCoordSet(moves_fN)).toEqual(toCoordSet(moves_ffN));
         });
 
+        it("should handle the 'h' modifier to get all forward moves for a Knight", () => {
+            const moves = parser.parse('fhN');
+            const expected = new Set(['-1,2', '1,2', '-2,1', '2,1']);
+            expect(toCoordSet(moves)).toEqual(expected);
+        });
+
+        it("should handle union of doubled modifiers like 'ffrrN'", () => {
+            const moves = parser.parse('ffrrN');
+            const expected = new Set(['-1,2', '1,2', '2,1', '2,-1']);
+            expect(toCoordSet(moves)).toEqual(expected);
+        });
+
         it('should correctly handle doubled sideways modifiers like srrC', () => {
             const moves = parser.parse('srrC');
             const expected = new Set(['3,1', '3,-1', '-3,1', '-3,-1']);
@@ -207,6 +219,18 @@ describe('BetzaParser', () => {
     });
 
     describe('Directional Shorthand Modifiers', () => {
+        it("should correctly handle 'vN' for a hippogonal piece", () => {
+            const moves = parser.parse('vN');
+            const expected = new Set(['-1,2', '1,2', '-1,-2', '1,-2']);
+            expect(toCoordSet(moves)).toEqual(expected);
+        });
+
+        it("should correctly handle 'sN' for a hippogonal piece", () => {
+            const moves = parser.parse('sN');
+            const expected = new Set(['-2,1', '2,1', '-2,-1', '2,-1']);
+            expect(toCoordSet(moves)).toEqual(expected);
+        });
+
         it("should correctly handle the vertical 'v' modifier on a Rook", () => {
             const moves = parser.parse('vR');
             const moveCoords = toCoordSet(moves);


### PR DESCRIPTION
The parsing of directional modifiers for hippogonal pieces (e.g., Knight) was not aligned with the Fairy-Stockfish standard. Previously, a single-letter modifier like 'f' in 'fN' was not treated as a doubled modifier ('ff'), which is the expected behavior for a Shogi Knight.

This commit updates the Betza parsing logic in both the Python and TypeScript implementations to correctly handle these modifiers.

- The `_filter_directions` method in `betza_parser.py` and `_filterDirections` in `src/betza_parser.ts` have been updated with a more robust logic that correctly interprets single-letter directional modifiers as doubled for hippogonal pieces.
- The new logic correctly handles simple cases (e.g., 'fN'), complex combinations (e.g., 'fbN'), and quadrant restrictions (e.g., 'fflN') consistently.
- The previous hardcoded special case for 'fbN' has been removed, as it is now covered by the generalized logic.
- Unit tests for both implementations have been updated to reflect the correct behavior, including a new test for 'fN' and an updated test to ensure 'ffN' remains compatible.