### PR TITLE
Fix: Correctly parse custom king moves

### DIFF
--- a/fsf_built_in_variants_catalog.json
+++ b/fsf_built_in_variants_catalog.json
@@ -1882,7 +1882,7 @@
   {
     "name": "King",
     "variant": "knightmate",
-    "betza": "K"
+    "betza": "N"
   },
   {
     "name": "Pawn",
@@ -2337,7 +2337,7 @@
   {
     "name": "King",
     "variant": "minixiangqi",
-    "betza": "K"
+    "betza": "W"
   },
   {
     "name": "Rook",

--- a/fsf_built_in_variants_catalog.json
+++ b/fsf_built_in_variants_catalog.json
@@ -1567,7 +1567,7 @@
   {
     "name": "King",
     "variant": "janggi",
-    "betza": "K"
+    "betza": "W"
   },
   {
     "name": "Rook",
@@ -1602,7 +1602,7 @@
   {
     "name": "King",
     "variant": "janggicasual",
-    "betza": "K"
+    "betza": "W"
   },
   {
     "name": "Rook",
@@ -1637,7 +1637,7 @@
   {
     "name": "King",
     "variant": "janggimodern",
-    "betza": "K"
+    "betza": "W"
   },
   {
     "name": "Rook",
@@ -1672,7 +1672,7 @@
   {
     "name": "King",
     "variant": "janggitraditional",
-    "betza": "K"
+    "betza": "W"
   },
   {
     "name": "Rook",
@@ -2182,7 +2182,7 @@
   {
     "name": "King",
     "variant": "manchu",
-    "betza": "K"
+    "betza": "W"
   },
   {
     "name": "Rook",
@@ -3427,7 +3427,7 @@
   {
     "name": "King",
     "variant": "supply",
-    "betza": "K"
+    "betza": "W"
   },
   {
     "name": "Rook",
@@ -3697,7 +3697,7 @@
   {
     "name": "King",
     "variant": "xiangqi",
-    "betza": "K"
+    "betza": "W"
   },
   {
     "name": "Rook",

--- a/parse_cpp.py
+++ b/parse_cpp.py
@@ -161,8 +161,16 @@ class CppParser:
             if variant_name.endswith('_base'):
                 continue
             if func_name in final_pieces_by_func:
-                variant_info = self.raw_variant_defs[func_name]
-                king_type_enum = variant_info.get('king_type')
+                # Find the effective king_type by traversing the inheritance chain
+                current_func = func_name
+                king_type_enum = None
+                while current_func:
+                    current_variant_info = self.raw_variant_defs.get(current_func, {})
+                    if current_variant_info.get('king_type'):
+                        king_type_enum = current_variant_info['king_type']
+                        break
+                    current_func = current_variant_info.get('parent')
+
                 king_betza = None
                 if king_type_enum and king_type_enum in self.piece_defs:
                     king_betza = self.piece_defs[king_type_enum]['betza']

--- a/parse_cpp.py
+++ b/parse_cpp.py
@@ -57,11 +57,13 @@ class CppParser:
 
             reset_pieces = 'v->reset_pieces();' in body
             removals = re.findall(r'v->remove_piece\((\w+)\);', body)
+            king_type_match = re.search(r'v->kingType\s*=\s*(\w+);', body)
+            king_type = king_type_match.group(1) if king_type_match else None
             additions = []
             add_pattern = re.compile(r'v->add_piece\((\w+),\s*\'(\w)\'(?:,\s*[\'"]([^"\']*)[\'"])?\);')
             for add_match in add_pattern.finditer(body):
                 additions.append({ 'enum': add_match.group(1), 'char': add_match.group(2), 'betza': add_match.group(3) if add_match.group(3) and add_match.group(1).startswith("CUSTOM_PIECE_") else None })
-            self.raw_variant_defs[func_name] = { 'parent': parent, 'removals': removals, 'additions': additions, 'reset_pieces': reset_pieces }
+            self.raw_variant_defs[func_name] = { 'parent': parent, 'removals': removals, 'additions': additions, 'reset_pieces': reset_pieces, 'king_type': king_type }
 
         map_init_body_match = re.search(r'void\s+VariantMap::init\(\)\s*\{([\s\S]*?)\}', variant_cpp_content, re.DOTALL)
         if map_init_body_match:
@@ -159,8 +161,18 @@ class CppParser:
             if variant_name.endswith('_base'):
                 continue
             if func_name in final_pieces_by_func:
+                variant_info = self.raw_variant_defs[func_name]
+                king_type_enum = variant_info.get('king_type')
+                king_betza = None
+                if king_type_enum and king_type_enum in self.piece_defs:
+                    king_betza = self.piece_defs[king_type_enum]['betza']
+
                 for enum, piece_info in final_pieces_by_func[func_name].items():
                     internal_name = piece_info['name']
+                    betza = piece_info['betza']
+
+                    if enum == 'KING' and king_betza is not None:
+                        betza = king_betza
 
                     if '_' in internal_name:
                         display_name = internal_name.replace('_', ' ').title()
@@ -173,7 +185,7 @@ class CppParser:
                     output.append({
                         'name': display_name,
                         'variant': variant_name,
-                        'betza': piece_info['betza']
+                        'betza': betza
                     })
 
         output.sort(key=lambda x: (x['variant'], x['name']))

--- a/src/variant_ini_parser.ts
+++ b/src/variant_ini_parser.ts
@@ -129,7 +129,7 @@ export class VariantIniParser {
 
           const isCustom = key.startsWith('customPiece');
           const variantNameTitle = variantName.charAt(0).toUpperCase() + variantName.slice(1);
-          const pieceName = isCustom ? `${variantNameTitle}-${pieceChar}` : key;
+          const pieceName = isCustom ? `${variantNameTitle}-${pieceChar}` : titleCase(key);
 
           let found = false;
           for (const piece of pieces) {

--- a/tests/python_unittests/test_variant_ini_parser.py
+++ b/tests/python_unittests/test_variant_ini_parser.py
@@ -87,6 +87,22 @@ king = k:KN
         self.assertIsNotNone(centaur_king)
         self.assertEqual(centaur_king['betza'], 'KN')
 
+    def test_king_override_inheritance(self):
+        ini_content = """
+[basevariant]
+king = k:N
+
+[childvariant:basevariant]
+pawn = p:fW
+"""
+        piece_catalog = []
+        parser = VariantIniParser(ini_content, piece_catalog)
+        pieces = parser.parse()
+
+        child_king = next((p for p in pieces if p['name'] == 'King' and p['variant'] == 'childvariant'), None)
+        self.assertIsNotNone(child_king)
+        self.assertEqual(child_king['betza'], 'N')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/python_unittests/test_variant_ini_parser.py
+++ b/tests/python_unittests/test_variant_ini_parser.py
@@ -71,5 +71,22 @@ customPiece1 = p:mWfceFifmnD
         self.assertIsNotNone(allways_pawn)
         self.assertEqual(allways_pawn["betza"], "mWfceFifmnD")
 
+    def test_king_override(self):
+        ini_content = """
+[centaurking:chess]
+king = k:KN
+"""
+        piece_catalog = [
+            {"name": "King", "variant": "chess", "betza": "K"},
+            {"name": "Pawn", "variant": "chess", "betza": "fmWfceF"}
+        ]
+        parser = VariantIniParser(ini_content, piece_catalog)
+        pieces = parser.parse()
+
+        centaur_king = next((p for p in pieces if p['name'] == 'King' and p['variant'] == 'centaurking'), None)
+        self.assertIsNotNone(centaur_king)
+        self.assertEqual(centaur_king['betza'], 'KN')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/yarn_tests/variant_ini_parser.test.ts
+++ b/tests/yarn_tests/variant_ini_parser.test.ts
@@ -76,4 +76,21 @@ customPiece1 = p:mWfceFifmnD
     expect(allwaysPawn).toBeDefined();
     expect(allwaysPawn?.betza).toBe('mWfceFifmnD');
   });
+
+  it('should override the king\'s betza string', () => {
+    const iniContent = `
+[centaurking:chess]
+king = k:KN
+`;
+    const pieceCatalog = [
+      { name: 'King', variant: 'chess', betza: 'K' },
+      { name: 'Pawn', variant: 'chess', betza: 'fmWfceF' },
+    ];
+    const parser = new VariantIniParser(iniContent, pieceCatalog);
+    const pieces = parser.parse();
+
+    const centaurKing = pieces.find(p => p.name === 'King' && p.variant === 'centaurking');
+    expect(centaurKing).toBeDefined();
+    expect(centaurKing?.betza).toBe('KN');
+  });
 });

--- a/tests/yarn_tests/variant_ini_parser.test.ts
+++ b/tests/yarn_tests/variant_ini_parser.test.ts
@@ -93,4 +93,21 @@ king = k:KN
     expect(centaurKing).toBeDefined();
     expect(centaurKing?.betza).toBe('KN');
   });
+
+  it('should handle king override inheritance', () => {
+    const iniContent = `
+[basevariant]
+king = k:N
+
+[childvariant:basevariant]
+pawn = p:fW
+`;
+    const pieceCatalog: Piece[] = [];
+    const parser = new VariantIniParser(iniContent, pieceCatalog);
+    const pieces = parser.parse();
+
+    const childKing = pieces.find(p => p.name === 'King' && p.variant === 'childvariant');
+    expect(childKing).toBeDefined();
+    expect(childKing?.betza).toBe('N');
+  });
 });

--- a/variant_ini_parser.py
+++ b/variant_ini_parser.py
@@ -81,7 +81,7 @@ class VariantIniParser:
                     if is_custom:
                         piece_name = f"{variant_name.title()}-{piece_char}"
                     else:
-                        piece_name = key
+                        piece_name = key.title()
 
                     found = False
                     for piece in pieces:


### PR DESCRIPTION
The `parse_cpp.py` script was not parsing the `kingType` property from the C++ variant definitions in Fairy-Stockfish. This caused some variants, such as `knightmate` and `minixiangqi`, to have an incorrect Betza string for their king piece.

This commit updates `parse_cpp.py` to:
- Extract the `kingType` enum for each variant.
- Use the `kingType` to look up the correct Betza string for the king.
- Apply this Betza string to the King piece for the respective variant.

The `fsf_built_in_variants_catalog.json` has been regenerated to reflect these changes.