### PR TITLE
feat: Add visual indicators for initial moves

### DIFF
--- a/betza_parser.py
+++ b/betza_parser.py
@@ -119,19 +119,22 @@ class BetzaParser:
             base_directions = self._get_directions(x_atom, y_atom)
             allowed_directions = self._filter_directions(base_directions, mods_for_this_atom, atom)
 
+            is_initial_only = "i" in mods_for_this_atom
+
             for i in range(1, max_steps + 1):
                 for dx, dy in allowed_directions:
-                    moves.append(
-                        {
-                            "x": dx * i,
-                            "y": dy * i,
-                            "move_type": move_type,
-                            "hop_type": hop_type,
-                            "jump_type": jump_type,
-                            "atom": atom,
-                            "atom_coords": {"x": x_atom, "y": y_atom},
-                        }
-                    )
+                    move = {
+                        "x": dx * i,
+                        "y": dy * i,
+                        "move_type": move_type,
+                        "hop_type": hop_type,
+                        "jump_type": jump_type,
+                        "atom": atom,
+                        "atom_coords": {"x": x_atom, "y": y_atom},
+                    }
+                    if is_initial_only:
+                        move["initial_only"] = True
+                    moves.append(move)
 
         return moves
 

--- a/main.py
+++ b/main.py
@@ -29,7 +29,7 @@ def sign(n):
 
 DEFAULT_BOARD_SIZE = 15
 
-LEGEND_TEXT = "m: Move | x: Capture | X: Move/Capture | ♙: Blocker | H: Capture on Blocker | #: Move/Capture on Blocker"
+LEGEND_TEXT = "m: Move | x: Capture | X: Move/Capture | i: Initial | ♙: Blocker | H: Capture on Blocker | #: Move/Capture on Blocker"
 
 
 class BetzaChessApp(App):
@@ -275,7 +275,18 @@ class BetzaChessApp(App):
 
             if is_valid:
                 is_on_blocker = (x, y) in self.blockers
+                is_initial = move.get("initial_only", False)
+
                 char = move_map.get(move_type, "?")
+
+                if is_initial:
+                    if char == "m":
+                        char = "i"
+                    elif char == "x":
+                        char = "c"
+                    elif char == "X":
+                        char = "I"
+
                 if is_on_blocker:
                     if char == "m":
                         char = "M"

--- a/src/betza_parser.ts
+++ b/src/betza_parser.ts
@@ -128,6 +128,8 @@ export class BetzaParser {
         atom
       );
 
+      const isInitialOnly = modsForThisAtom.includes('i');
+
       for (let i = 1; i <= maxSteps; i++) {
         for (const { dx, dy } of allowedDirections) {
           const move: Move = {
@@ -139,6 +141,9 @@ export class BetzaParser {
             atom,
             atomCoords: { x: atomX, y: atomY },
           };
+          if (isInitialOnly) {
+            move.initialOnly = true;
+          }
           moves.push(move);
         }
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -234,7 +234,8 @@ function renderBoard(moves: Move[], blockers: Set<string>) {
     if (!isValid) return;
 
     const isSpecialMove = hopType !== null;
-    const moveIndicator = createMoveIndicator(moveType, isSpecialMove);
+    const isInitial = move.initialOnly || false;
+    const moveIndicator = createMoveIndicator(moveType, isSpecialMove, isInitial);
     moveIndicator.setAttribute('transform', `translate(${cx}, ${cy})`);
     svg.appendChild(moveIndicator);
   });
@@ -320,6 +321,13 @@ function renderLegend() {
     createLegendItem(moveCaptureIcon, 'Move or Capture')
   );
   legendContainer.appendChild(createLegendItem(hopIcon, 'Hop'));
+
+  const initialIcon = `<svg width="30" height="30" viewBox="0 0 30 30"><circle cx="15" cy="15" r="${
+    r * 0.75
+  }" stroke="${
+    COLORS.initial
+  }" stroke-width="${strokeWidth}" fill="none" /></svg>`;
+  legendContainer.appendChild(createLegendItem(initialIcon, 'Initial'));
 }
 
 function populateVariantFilter(

--- a/src/svg_utils.ts
+++ b/src/svg_utils.ts
@@ -8,6 +8,7 @@ export const COLORS = {
   move: '#FFD700',
   capture: '#DC143C',
   hop: '#32CD32',
+  initial: '#87CEEB', // Sky Blue
   blocker: '#606060',
 };
 
@@ -29,7 +30,8 @@ function createPath(d: string, color: string, strokeWidth: string): SVGPathEleme
  */
 export function createMoveIndicator(
   moveType: Move['moveType'],
-  isSpecialMove: boolean
+  isSpecialMove: boolean,
+  isInitial: boolean
 ): SVGElement {
   const r = CELL_SIZE * 0.3;
   const strokeWidth = '4';
@@ -38,20 +40,28 @@ export function createMoveIndicator(
   const moveIndicatorGroup = document.createElementNS(SVG_NS, 'g');
   moveIndicatorGroup.setAttribute('opacity', opacity);
 
+  if (isInitial) {
+    moveIndicatorGroup.classList.add('initial-move');
+  }
+
   const fullCircleD = `M 0,${-r} A ${r},${r} 0 1 1 0,${r} A ${r},${r} 0 1 1 0,${-r}`;
   const leftSemiCircleD = `M 0,${-r} A ${r},${r} 0 0 0 0,${r}`;
   const rightSemiCircleD = `M 0,${-r} A ${r},${r} 0 0 1 0,${r}`;
+
+  const moveColor = isInitial ? COLORS.initial : COLORS.move;
 
   if (isSpecialMove) {
     moveIndicatorGroup.appendChild(createPath(fullCircleD, COLORS.hop, strokeWidth));
   } else {
     if (moveType === 'move') {
-      moveIndicatorGroup.appendChild(createPath(fullCircleD, COLORS.move, strokeWidth));
+      moveIndicatorGroup.appendChild(createPath(fullCircleD, moveColor, strokeWidth));
     } else if (moveType === 'capture') {
-      moveIndicatorGroup.appendChild(createPath(fullCircleD, COLORS.capture, strokeWidth));
+      const captureColor = isInitial ? COLORS.initial : COLORS.capture;
+      moveIndicatorGroup.appendChild(createPath(fullCircleD, captureColor, strokeWidth));
     } else if (moveType === 'move_capture') {
-      moveIndicatorGroup.appendChild(createPath(leftSemiCircleD, COLORS.move, strokeWidth));
-      moveIndicatorGroup.appendChild(createPath(rightSemiCircleD, COLORS.capture, strokeWidth));
+      const captureColor = isInitial ? COLORS.initial : COLORS.capture;
+      moveIndicatorGroup.appendChild(createPath(leftSemiCircleD, moveColor, strokeWidth));
+      moveIndicatorGroup.appendChild(createPath(rightSemiCircleD, captureColor, strokeWidth));
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,4 +12,5 @@ export interface Move {
   jumpType: 'normal' | 'non-jumping' | 'jumping';
   atom: string;
   atomCoords: { x: number; y: number };
+  initialOnly?: boolean;
 }

--- a/style.css
+++ b/style.css
@@ -141,3 +141,7 @@ body {
 .legend-icon-emoji {
     font-size: 24px;
 }
+
+.initial-move path {
+    stroke: var(--initial-move-color, #87CEEB); /* Sky Blue */
+}

--- a/tests/pytest_tests/test_tui.py
+++ b/tests/pytest_tests/test_tui.py
@@ -44,7 +44,7 @@ def count_moves_on_board(board_text: str) -> int:
     """
     Counts the number of move indicators on the board.
     """
-    move_chars = {"m", "x", "X", "H", "#"}
+    move_chars = {"m", "x", "X", "H", "#", "i", "I", "c"}
     return sum(1 for char in board_text if char in move_chars)
 
 
@@ -298,3 +298,18 @@ async def test_janggi_elephant_moves(pilot: Pilot):
     rows = board_text.split('\n')
     assert rows[center - 3][(center + 2) * 2] == '.'
     assert rows[center - 3][(center - 2) * 2] == '.'
+
+
+async def test_initial_move_character(pilot: Pilot):
+    """
+    Tests that an initial-only move is rendered with a special character.
+    """
+    await pilot.pause()
+    input_widget = pilot.app.query_one("#betza_input")
+    await pilot.click(input_widget)
+    await pilot.press("i", "W")
+    await pilot.pause()
+
+    board_text = pilot.app.query_one("#board").render()
+    assert "I" in board_text
+    assert "X" not in board_text

--- a/tests/pytest_tests/test_web_app.py
+++ b/tests/pytest_tests/test_web_app.py
@@ -259,3 +259,16 @@ def test_load_variants_from_ini(page: Page):
     # The minishogi variant in the test file has 8 pieces.
     piece_catalog = page.locator("#piece-catalog-content")
     expect(piece_catalog.locator(".piece-catalog-item")).to_have_count(8)
+
+
+@pytest.mark.e2e
+def test_initial_move_class(page: Page):
+    """
+    Tests that an initial-only move is rendered with a special class for styling.
+    """
+    page.goto("http://localhost:8080")
+    page.locator("#betzaInput").fill("imW")
+    page.locator("#betzaInput").dispatch_event("input")
+
+    # There should be 4 moves, all with the initial-move class.
+    expect(page.locator("g.initial-move")).to_have_count(4)

--- a/tests/python_unittests/test_betza_parser.py
+++ b/tests/python_unittests/test_betza_parser.py
@@ -241,6 +241,25 @@ if __name__ == "__main__":
     unittest.main()
 
 
+class TestInitialModifier(unittest.TestCase):
+    """Tests for the 'i' (initial) modifier."""
+
+    def setUp(self):
+        self.parser = BetzaParser()
+
+    def test_initial_modifier_iW(self):
+        """Tests that 'iW' flags moves as initial only."""
+        moves = self.parser.parse("iW")
+        self.assertEqual(len(moves), 4)
+        self.assertTrue(all(m.get("initial_only") for m in moves))
+
+    def test_no_initial_modifier_W(self):
+        """Tests that 'W' does not have the initial_only flag."""
+        moves = self.parser.parse("W")
+        self.assertEqual(len(moves), 4)
+        self.assertTrue(all("initial_only" not in m for m in moves))
+
+
 class TestModifierScope(unittest.TestCase):
     """Tests that modifiers are correctly scoped to their respective atoms."""
 

--- a/tests/yarn_tests/betza_parser.test.ts
+++ b/tests/yarn_tests/betza_parser.test.ts
@@ -321,4 +321,18 @@ describe('BetzaParser', () => {
       expect(moveCoords).toEqual(expected);
     });
   });
+
+  describe('Initial Modifier', () => {
+    it('should correctly handle the initial "i" modifier', () => {
+        const moves = parser.parse('iW');
+        expect(moves.length).toBe(4);
+        expect(moves.every(m => m.initialOnly === true)).toBe(true);
+    });
+
+    it('should not have the initialOnly flag for a normal piece', () => {
+        const moves = parser.parse('W');
+        expect(moves.length).toBe(4);
+        expect(moves.every(m => m.initialOnly === undefined)).toBe(true);
+    });
+  });
 });

--- a/tests/yarn_tests/svg_utils.test.ts
+++ b/tests/yarn_tests/svg_utils.test.ts
@@ -2,7 +2,7 @@ import { createMoveIndicator, COLORS, CELL_SIZE } from '../../src/svg_utils.js';
 
 describe('createMoveIndicator', () => {
   it('should create a full circle for a "move" type', () => {
-    const indicator = createMoveIndicator('move', false);
+    const indicator = createMoveIndicator('move', false, false);
     expect(indicator.tagName).toBe('g');
     expect(indicator.childNodes.length).toBe(1);
 
@@ -16,7 +16,7 @@ describe('createMoveIndicator', () => {
   });
 
   it('should create a move indicator for a "capture" type', () => {
-    const indicator = createMoveIndicator('capture', false);
+    const indicator = createMoveIndicator('capture', false, false);
     expect(indicator.tagName).toBe('g');
     expect(indicator.childNodes.length).toBe(1);
 
@@ -26,7 +26,7 @@ describe('createMoveIndicator', () => {
   });
 
   it('should create a move indicator for a "move_capture" type', () => {
-    const indicator = createMoveIndicator('move_capture', false);
+    const indicator = createMoveIndicator('move_capture', false, false);
     expect(indicator.tagName).toBe('g');
     expect(indicator.childNodes.length).toBe(2);
 
@@ -40,12 +40,17 @@ describe('createMoveIndicator', () => {
   });
 
   it('should create a move indicator for a special move', () => {
-    const indicator = createMoveIndicator('move_capture', true);
+    const indicator = createMoveIndicator('move_capture', true, false);
     expect(indicator.tagName).toBe('g');
     expect(indicator.childNodes.length).toBe(1);
 
     const path = indicator.childNodes[0] as SVGPathElement;
     expect(path.tagName).toBe('path');
     expect(path.getAttribute('stroke')).toBe(COLORS.hop);
+  });
+
+  it('should add the initial-move class for an initial move', () => {
+    const indicator = createMoveIndicator('move', false, true);
+    expect(indicator.classList.contains('initial-move')).toBe(true);
   });
 });


### PR DESCRIPTION
This commit adds visual indicators for initial-only moves in both the TUI and web interfaces.

- In the TUI, initial moves are now represented by 'i' (move), 'c' (capture), or 'I' (move/capture).
- In the web interface, initial moves are colored with a distinct blue color.
- The legends in both interfaces have been updated to reflect these changes.
- Interface tests have been added for both the TUI and web app to verify the new visual indicators.

This completes the implementation of the 'i' modifier feature.

Fixes #64