### PR TITLE
Fix initial double move of Fairy-Stockfish built in standard chess pa…

### DIFF
--- a/fsf_built_in_variant_properties.json
+++ b/fsf_built_in_variant_properties.json
@@ -1,0 +1,362 @@
+{
+  "chess": {
+    "double_step": true
+  },
+  "normal": {
+    "double_step": true
+  },
+  "fischerandom": {
+    "double_step": true
+  },
+  "nocastle": {
+    "double_step": true
+  },
+  "armageddon": {
+    "double_step": true
+  },
+  "torpedo": {
+    "double_step": true
+  },
+  "berolina": {
+    "double_step": true
+  },
+  "pawnsideways": {
+    "double_step": true
+  },
+  "pawnback": {
+    "double_step": true
+  },
+  "legan": {
+    "double_step": false
+  },
+  "fairy": {
+    "double_step": true
+  },
+  "makruk": {
+    "double_step": false
+  },
+  "makpong": {
+    "double_step": false
+  },
+  "cambodian": {
+    "double_step": false
+  },
+  "karouk": {
+    "double_step": false
+  },
+  "asean": {
+    "double_step": false
+  },
+  "ai-wok": {
+    "double_step": false
+  },
+  "shatranj": {
+    "double_step": false
+  },
+  "chaturanga": {
+    "double_step": false
+  },
+  "amazon": {
+    "double_step": true
+  },
+  "nightrider": {
+    "double_step": true
+  },
+  "grasshopper": {
+    "double_step": false
+  },
+  "hoppelpoppel": {
+    "double_step": true
+  },
+  "newzealand": {
+    "double_step": true
+  },
+  "kingofthehill": {
+    "double_step": true
+  },
+  "racingkings": {
+    "double_step": true
+  },
+  "knightmate": {
+    "double_step": true
+  },
+  "misere": {
+    "double_step": true
+  },
+  "losers": {
+    "double_step": true
+  },
+  "giveaway": {
+    "double_step": true
+  },
+  "antichess": {
+    "double_step": true
+  },
+  "suicide": {
+    "double_step": true
+  },
+  "codrus": {
+    "double_step": true
+  },
+  "extinction": {
+    "double_step": true
+  },
+  "kinglet": {
+    "double_step": true
+  },
+  "threekings": {
+    "double_step": true
+  },
+  "horde": {
+    "double_step": true
+  },
+  "petrified": {
+    "double_step": true
+  },
+  "nocheckatomic": {
+    "double_step": true
+  },
+  "atomic": {
+    "double_step": true
+  },
+  "atomar": {
+    "double_step": true
+  },
+  "isolation": {
+    "double_step": true
+  },
+  "isolation7x7": {
+    "double_step": true
+  },
+  "snailtrail": {
+    "double_step": true
+  },
+  "fox-and-hounds": {
+    "double_step": true
+  },
+  "duck": {
+    "double_step": true
+  },
+  "joust": {
+    "double_step": true
+  },
+  "3check": {
+    "double_step": true
+  },
+  "5check": {
+    "double_step": true
+  },
+  "crazyhouse": {
+    "double_step": true
+  },
+  "loop": {
+    "double_step": true
+  },
+  "chessgi": {
+    "double_step": true
+  },
+  "bughouse": {
+    "double_step": true
+  },
+  "koedem": {
+    "double_step": true
+  },
+  "pocketknight": {
+    "double_step": true
+  },
+  "placement": {
+    "double_step": true
+  },
+  "sittuyin": {
+    "double_step": false
+  },
+  "seirawan": {
+    "double_step": true
+  },
+  "shouse": {
+    "double_step": true
+  },
+  "dragon": {
+    "double_step": true
+  },
+  "paradigm": {
+    "double_step": true
+  },
+  "minishogi": {
+    "double_step": false
+  },
+  "mini": {
+    "double_step": false
+  },
+  "kyotoshogi": {
+    "double_step": false
+  },
+  "micro": {
+    "double_step": false
+  },
+  "dobutsu": {
+    "double_step": false
+  },
+  "gorogoro": {
+    "double_step": false
+  },
+  "judkins": {
+    "double_step": false
+  },
+  "torishogi": {
+    "double_step": false
+  },
+  "euroshogi": {
+    "double_step": false
+  },
+  "losalamos": {
+    "double_step": false
+  },
+  "gardner": {
+    "double_step": false
+  },
+  "almost": {
+    "double_step": true
+  },
+  "sortofalmost": {
+    "double_step": false
+  },
+  "chigorin": {
+    "double_step": true
+  },
+  "perfect": {
+    "double_step": true
+  },
+  "spartan": {
+    "double_step": true
+  },
+  "shatar": {
+    "double_step": false
+  },
+  "coregal": {
+    "double_step": true
+  },
+  "clobber": {
+    "double_step": false
+  },
+  "breakthrough": {
+    "double_step": false
+  },
+  "ataxx": {
+    "double_step": false
+  },
+  "flipersi": {
+    "double_step": false
+  },
+  "flipello": {
+    "double_step": false
+  },
+  "minixiangqi": {
+    "double_step": false
+  },
+  "raazuvaa": {
+    "double_step": false
+  },
+  "shogi": {
+    "double_step": false
+  },
+  "checkshogi": {
+    "double_step": false
+  },
+  "shoshogi": {
+    "double_step": false
+  },
+  "yarishogi": {
+    "double_step": false
+  },
+  "okisakishogi": {
+    "double_step": false
+  },
+  "capablanca": {
+    "double_step": true
+  },
+  "capahouse": {
+    "double_step": true
+  },
+  "caparandom": {
+    "double_step": true
+  },
+  "gothic": {
+    "double_step": true
+  },
+  "janus": {
+    "double_step": true
+  },
+  "modern": {
+    "double_step": true
+  },
+  "chancellor": {
+    "double_step": true
+  },
+  "embassy": {
+    "double_step": true
+  },
+  "centaur": {
+    "double_step": true
+  },
+  "gustav3": {
+    "double_step": true
+  },
+  "jesonmor": {
+    "double_step": false
+  },
+  "courier": {
+    "double_step": false
+  },
+  "grand": {
+    "double_step": true
+  },
+  "opulent": {
+    "double_step": true
+  },
+  "tencubed": {
+    "double_step": true
+  },
+  "omicron": {
+    "double_step": true
+  },
+  "troitzky": {
+    "double_step": true
+  },
+  "wolf": {
+    "double_step": true
+  },
+  "shako": {
+    "double_step": true
+  },
+  "clobber10": {
+    "double_step": false
+  },
+  "flipello10": {
+    "double_step": false
+  },
+  "amazons": {
+    "double_step": true
+  },
+  "xiangqi": {
+    "double_step": false
+  },
+  "manchu": {
+    "double_step": false
+  },
+  "supply": {
+    "double_step": false
+  },
+  "janggi": {
+    "double_step": false
+  },
+  "janggitraditional": {
+    "double_step": false
+  },
+  "janggimodern": {
+    "double_step": false
+  },
+  "janggicasual": {
+    "double_step": false
+  }
+}

--- a/fsf_built_in_variants_catalog.json
+++ b/fsf_built_in_variants_catalog.json
@@ -17,7 +17,7 @@
   {
     "name": "Pawn",
     "variant": "3check",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -47,7 +47,7 @@
   {
     "name": "Pawn",
     "variant": "5check",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -112,7 +112,7 @@
   {
     "name": "Pawn",
     "variant": "almost",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Rook",
@@ -142,7 +142,7 @@
   {
     "name": "Pawn",
     "variant": "amazon",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Rook",
@@ -172,7 +172,7 @@
   {
     "name": "Pawn",
     "variant": "antichess",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -202,7 +202,7 @@
   {
     "name": "Pawn",
     "variant": "armageddon",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -267,7 +267,7 @@
   {
     "name": "Pawn",
     "variant": "atomar",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -297,7 +297,7 @@
   {
     "name": "Pawn",
     "variant": "atomic",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -362,7 +362,7 @@
   {
     "name": "Pawn",
     "variant": "bughouse",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -432,7 +432,7 @@
   {
     "name": "Pawn",
     "variant": "capablanca",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -472,7 +472,7 @@
   {
     "name": "Pawn",
     "variant": "capahouse",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -512,7 +512,7 @@
   {
     "name": "Pawn",
     "variant": "caparandom",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -547,7 +547,7 @@
   {
     "name": "Pawn",
     "variant": "centaur",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -582,7 +582,7 @@
   {
     "name": "Pawn",
     "variant": "chancellor",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -692,7 +692,7 @@
   {
     "name": "Pawn",
     "variant": "chess",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -722,7 +722,7 @@
   {
     "name": "Pawn",
     "variant": "chessgi",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -757,7 +757,7 @@
   {
     "name": "Pawn",
     "variant": "chigorin",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -797,7 +797,7 @@
   {
     "name": "Pawn",
     "variant": "codrus",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -827,7 +827,7 @@
   {
     "name": "Pawn",
     "variant": "coregal",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -902,7 +902,7 @@
   {
     "name": "Pawn",
     "variant": "crazyhouse",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -962,7 +962,7 @@
   {
     "name": "Pawn",
     "variant": "dragon",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -992,7 +992,7 @@
   {
     "name": "Pawn",
     "variant": "duck",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -1032,7 +1032,7 @@
   {
     "name": "Pawn",
     "variant": "embassy",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -1107,7 +1107,7 @@
   {
     "name": "Pawn",
     "variant": "extinction",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -1157,7 +1157,7 @@
   {
     "name": "Pawn",
     "variant": "fairy",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -1192,7 +1192,7 @@
   {
     "name": "Pawn",
     "variant": "fischerandom",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -1277,7 +1277,7 @@
   {
     "name": "Pawn",
     "variant": "giveaway",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -1357,7 +1357,7 @@
   {
     "name": "Pawn",
     "variant": "gothic",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -1397,7 +1397,7 @@
   {
     "name": "Pawn",
     "variant": "grand",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -1467,7 +1467,7 @@
   {
     "name": "Pawn",
     "variant": "gustav3",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -1497,7 +1497,7 @@
   {
     "name": "Pawn",
     "variant": "hoppelpoppel",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -1527,7 +1527,7 @@
   {
     "name": "Pawn",
     "variant": "horde",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -1712,7 +1712,7 @@
   {
     "name": "Pawn",
     "variant": "janus",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -1827,7 +1827,7 @@
   {
     "name": "Pawn",
     "variant": "kinglet",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -1857,7 +1857,7 @@
   {
     "name": "Pawn",
     "variant": "kingofthehill",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -1887,7 +1887,7 @@
   {
     "name": "Pawn",
     "variant": "knightmate",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -1917,7 +1917,7 @@
   {
     "name": "Pawn",
     "variant": "koedem",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -2027,7 +2027,7 @@
   {
     "name": "Pawn",
     "variant": "loop",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -2082,7 +2082,7 @@
   {
     "name": "Pawn",
     "variant": "losers",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -2367,7 +2367,7 @@
   {
     "name": "Pawn",
     "variant": "misere",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -2402,7 +2402,7 @@
   {
     "name": "Pawn",
     "variant": "modern",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -2432,7 +2432,7 @@
   {
     "name": "Pawn",
     "variant": "newzealand",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -2462,7 +2462,7 @@
   {
     "name": "Pawn",
     "variant": "nightrider",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -2492,7 +2492,7 @@
   {
     "name": "Pawn",
     "variant": "nocastle",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -2522,7 +2522,7 @@
   {
     "name": "Pawn",
     "variant": "nocheckatomic",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -2552,7 +2552,7 @@
   {
     "name": "Pawn",
     "variant": "normal",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -2647,7 +2647,7 @@
   {
     "name": "Pawn",
     "variant": "omicron",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -2697,7 +2697,7 @@
   {
     "name": "Pawn",
     "variant": "opulent",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -2727,7 +2727,7 @@
   {
     "name": "Pawn",
     "variant": "paradigm",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -2832,7 +2832,7 @@
   {
     "name": "Pawn",
     "variant": "perfect",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -2892,7 +2892,7 @@
   {
     "name": "Pawn",
     "variant": "placement",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -2922,7 +2922,7 @@
   {
     "name": "Pawn",
     "variant": "pocketknight",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -2982,7 +2982,7 @@
   {
     "name": "Pawn",
     "variant": "racingkings",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -3022,7 +3022,7 @@
   {
     "name": "Pawn",
     "variant": "seirawan",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -3062,7 +3062,7 @@
   {
     "name": "Pawn",
     "variant": "shako",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -3267,7 +3267,7 @@
   {
     "name": "Pawn",
     "variant": "shouse",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -3347,7 +3347,7 @@
   {
     "name": "Pawn",
     "variant": "spartan",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -3392,7 +3392,7 @@
   {
     "name": "Pawn",
     "variant": "suicide",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -3467,7 +3467,7 @@
   {
     "name": "Pawn",
     "variant": "tencubed",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -3507,7 +3507,7 @@
   {
     "name": "Pawn",
     "variant": "threekings",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -3582,7 +3582,7 @@
   {
     "name": "Pawn",
     "variant": "torpedo",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -3612,7 +3612,7 @@
   {
     "name": "Pawn",
     "variant": "troitzky",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",
@@ -3647,7 +3647,7 @@
   {
     "name": "Pawn",
     "variant": "wolf",
-    "betza": "fmWfceF"
+    "betza": "fmWfceFimfnA"
   },
   {
     "name": "Queen",

--- a/fsf_built_in_variants_catalog.json
+++ b/fsf_built_in_variants_catalog.json
@@ -17,7 +17,7 @@
   {
     "name": "Pawn",
     "variant": "3check",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -47,7 +47,7 @@
   {
     "name": "Pawn",
     "variant": "5check",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -112,7 +112,7 @@
   {
     "name": "Pawn",
     "variant": "almost",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Rook",
@@ -142,7 +142,7 @@
   {
     "name": "Pawn",
     "variant": "amazon",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Rook",
@@ -172,7 +172,7 @@
   {
     "name": "Pawn",
     "variant": "antichess",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -202,7 +202,7 @@
   {
     "name": "Pawn",
     "variant": "armageddon",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -267,7 +267,7 @@
   {
     "name": "Pawn",
     "variant": "atomar",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -297,7 +297,7 @@
   {
     "name": "Pawn",
     "variant": "atomic",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -362,7 +362,7 @@
   {
     "name": "Pawn",
     "variant": "bughouse",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -432,7 +432,7 @@
   {
     "name": "Pawn",
     "variant": "capablanca",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -472,7 +472,7 @@
   {
     "name": "Pawn",
     "variant": "capahouse",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -512,7 +512,7 @@
   {
     "name": "Pawn",
     "variant": "caparandom",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -547,7 +547,7 @@
   {
     "name": "Pawn",
     "variant": "centaur",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -582,7 +582,7 @@
   {
     "name": "Pawn",
     "variant": "chancellor",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -692,7 +692,7 @@
   {
     "name": "Pawn",
     "variant": "chess",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -722,7 +722,7 @@
   {
     "name": "Pawn",
     "variant": "chessgi",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -757,7 +757,7 @@
   {
     "name": "Pawn",
     "variant": "chigorin",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -797,7 +797,7 @@
   {
     "name": "Pawn",
     "variant": "codrus",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -827,7 +827,7 @@
   {
     "name": "Pawn",
     "variant": "coregal",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -902,7 +902,7 @@
   {
     "name": "Pawn",
     "variant": "crazyhouse",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -962,7 +962,7 @@
   {
     "name": "Pawn",
     "variant": "dragon",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -992,7 +992,7 @@
   {
     "name": "Pawn",
     "variant": "duck",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -1032,7 +1032,7 @@
   {
     "name": "Pawn",
     "variant": "embassy",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -1107,7 +1107,7 @@
   {
     "name": "Pawn",
     "variant": "extinction",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -1157,7 +1157,7 @@
   {
     "name": "Pawn",
     "variant": "fairy",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -1192,7 +1192,7 @@
   {
     "name": "Pawn",
     "variant": "fischerandom",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -1277,7 +1277,7 @@
   {
     "name": "Pawn",
     "variant": "giveaway",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -1357,7 +1357,7 @@
   {
     "name": "Pawn",
     "variant": "gothic",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -1397,7 +1397,7 @@
   {
     "name": "Pawn",
     "variant": "grand",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -1467,7 +1467,7 @@
   {
     "name": "Pawn",
     "variant": "gustav3",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -1497,7 +1497,7 @@
   {
     "name": "Pawn",
     "variant": "hoppelpoppel",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -1527,7 +1527,7 @@
   {
     "name": "Pawn",
     "variant": "horde",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -1712,7 +1712,7 @@
   {
     "name": "Pawn",
     "variant": "janus",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -1827,7 +1827,7 @@
   {
     "name": "Pawn",
     "variant": "kinglet",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -1857,7 +1857,7 @@
   {
     "name": "Pawn",
     "variant": "kingofthehill",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -1887,7 +1887,7 @@
   {
     "name": "Pawn",
     "variant": "knightmate",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -1917,7 +1917,7 @@
   {
     "name": "Pawn",
     "variant": "koedem",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -2027,7 +2027,7 @@
   {
     "name": "Pawn",
     "variant": "loop",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -2082,7 +2082,7 @@
   {
     "name": "Pawn",
     "variant": "losers",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -2367,7 +2367,7 @@
   {
     "name": "Pawn",
     "variant": "misere",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -2402,7 +2402,7 @@
   {
     "name": "Pawn",
     "variant": "modern",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -2432,7 +2432,7 @@
   {
     "name": "Pawn",
     "variant": "newzealand",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -2462,7 +2462,7 @@
   {
     "name": "Pawn",
     "variant": "nightrider",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -2492,7 +2492,7 @@
   {
     "name": "Pawn",
     "variant": "nocastle",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -2522,7 +2522,7 @@
   {
     "name": "Pawn",
     "variant": "nocheckatomic",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -2552,7 +2552,7 @@
   {
     "name": "Pawn",
     "variant": "normal",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -2647,7 +2647,7 @@
   {
     "name": "Pawn",
     "variant": "omicron",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -2697,7 +2697,7 @@
   {
     "name": "Pawn",
     "variant": "opulent",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -2727,7 +2727,7 @@
   {
     "name": "Pawn",
     "variant": "paradigm",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -2832,7 +2832,7 @@
   {
     "name": "Pawn",
     "variant": "perfect",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -2892,7 +2892,7 @@
   {
     "name": "Pawn",
     "variant": "placement",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -2922,7 +2922,7 @@
   {
     "name": "Pawn",
     "variant": "pocketknight",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -2982,7 +2982,7 @@
   {
     "name": "Pawn",
     "variant": "racingkings",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -3022,7 +3022,7 @@
   {
     "name": "Pawn",
     "variant": "seirawan",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -3062,7 +3062,7 @@
   {
     "name": "Pawn",
     "variant": "shako",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -3267,7 +3267,7 @@
   {
     "name": "Pawn",
     "variant": "shouse",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -3347,7 +3347,7 @@
   {
     "name": "Pawn",
     "variant": "spartan",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -3392,7 +3392,7 @@
   {
     "name": "Pawn",
     "variant": "suicide",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -3467,7 +3467,7 @@
   {
     "name": "Pawn",
     "variant": "tencubed",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -3507,7 +3507,7 @@
   {
     "name": "Pawn",
     "variant": "threekings",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -3582,7 +3582,7 @@
   {
     "name": "Pawn",
     "variant": "torpedo",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -3612,7 +3612,7 @@
   {
     "name": "Pawn",
     "variant": "troitzky",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",
@@ -3647,7 +3647,7 @@
   {
     "name": "Pawn",
     "variant": "wolf",
-    "betza": "fmWfceFimfnA"
+    "betza": "fmWfceFifmnD"
   },
   {
     "name": "Queen",

--- a/main.py
+++ b/main.py
@@ -69,6 +69,8 @@ class BetzaChessApp(App):
         self.parser = BetzaParser()
         with open("fsf_built_in_variants_catalog.json", "r") as f:
             self.fsf_catalog = json.load(f)
+        with open("fsf_built_in_variant_properties.json", "r") as f:
+            self.fsf_variant_properties = json.load(f)
         self.piece_catalog = self.fsf_catalog
         self.query_one("#board").update(self.render_board())
         self.query_one(Input).focus()
@@ -83,7 +85,7 @@ class BetzaChessApp(App):
             try:
                 with open(path, "r") as f:
                     ini_content = f.read()
-                ini_parser = VariantIniParser(ini_content, self.fsf_catalog)
+                ini_parser = VariantIniParser(ini_content, self.fsf_catalog, self.fsf_variant_properties)
                 ini_pieces = ini_parser.parse()
                 self.piece_catalog = self.fsf_catalog + ini_pieces
                 self.populate_variant_select()

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "format": "prettier --write \"src/**/*.ts\"",
     "clean": "rm -rf dist && find tests -name '*.js' -delete && find src -name '*.js' -delete",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
-    "build": "yarn clean && ./node_modules/typescript/bin/tsc && cp index.html style.css fsf_built_in_variants_catalog.json dist/"
+    "build": "yarn clean && ./node_modules/typescript/bin/tsc && cp index.html style.css fsf_built_in_variants_catalog.json fsf_built_in_variant_properties.json dist/"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",

--- a/parse_cpp.py
+++ b/parse_cpp.py
@@ -208,7 +208,7 @@ class CppParser:
                         betza = king_betza
 
                     if enum == 'PAWN' and double_step:
-                        betza += 'imfnA'
+                        betza += 'ifmnD'
 
                     if '_' in internal_name:
                         display_name = internal_name.replace('_', ' ').title()

--- a/src/main.ts
+++ b/src/main.ts
@@ -400,15 +400,20 @@ function renderPieceCatalog(
 
 async function initialize() {
   let pieceCatalog: Piece[] = [];
+  let variantProperties: { [key: string]: any } = {};
   renderBoard([], blockers);
   renderLegend();
   try {
-    const response = await fetch('/fsf_built_in_variants_catalog.json');
-    pieceCatalog = await response.json();
+    const catalogResponse = await fetch('/fsf_built_in_variants_catalog.json');
+    pieceCatalog = await catalogResponse.json();
+
+    const propertiesResponse = await fetch('/fsf_built_in_variant_properties.json');
+    variantProperties = await propertiesResponse.json();
+
     populateVariantFilter(pieceCatalog);
     renderPieceCatalog(pieceCatalog);
   } catch (error) {
-    console.error('Error loading piece catalog:', error);
+    console.error('Error loading data:', error);
   }
 
   inputEl.addEventListener('input', updateBoard);
@@ -440,7 +445,7 @@ async function initialize() {
       const content = e.target?.result as string;
       if (content) {
         try {
-          const iniParser = new VariantIniParser(content, pieceCatalog);
+          const iniParser = new VariantIniParser(content, pieceCatalog, variantProperties);
           const newPieces = iniParser.parse();
           pieceCatalog.push(...newPieces);
           populateVariantFilter(pieceCatalog);

--- a/src/variant_ini_parser.ts
+++ b/src/variant_ini_parser.ts
@@ -176,8 +176,8 @@ export class VariantIniParser {
 
     if (props.double_step) {
         for (const piece of pieces) {
-            if (piece.name.toLowerCase() === 'pawn' && !piece.betza.includes('imfnA')) {
-                piece.betza += 'imfnA';
+            if (piece.name.toLowerCase() === 'pawn' && !piece.betza.includes('ifmnD')) {
+                piece.betza += 'ifmnD';
             }
         }
     }

--- a/tests/pytest_tests/test_tui.py
+++ b/tests/pytest_tests/test_tui.py
@@ -37,7 +37,7 @@ async def test_piece_catalog_selection(pilot: Pilot):
     await pilot.press("down")
     await pilot.press("enter")
     await pilot.pause()
-    assert input_widget.value == "fmWfceF"
+    assert input_widget.value == "fmWfceFimfnA"
 
 
 def count_moves_on_board(board_text: str) -> int:

--- a/tests/pytest_tests/test_tui.py
+++ b/tests/pytest_tests/test_tui.py
@@ -37,7 +37,7 @@ async def test_piece_catalog_selection(pilot: Pilot):
     await pilot.press("down")
     await pilot.press("enter")
     await pilot.pause()
-    assert input_widget.value == "fmWfceFimfnA"
+    assert input_widget.value == "fmWfceF" + "ifmnD"
 
 
 def count_moves_on_board(board_text: str) -> int:

--- a/tests/python_unittests/test_variant_ini_parser.py
+++ b/tests/python_unittests/test_variant_ini_parser.py
@@ -131,11 +131,11 @@ doubleStep = false
 
         pawn1 = next((p for p in pieces if p['variant'] == 'withdoublestep' and p['name'] == 'Pawn'), None)
         self.assertIsNotNone(pawn1)
-        self.assertTrue('imfnA' in pawn1['betza'])
+        self.assertTrue('ifmnD' in pawn1['betza'])
 
         pawn2 = next((p for p in pieces if p['variant'] == 'withoutdoublestep' and p['name'] == 'Pawn'), None)
         self.assertIsNotNone(pawn2)
-        self.assertFalse('imfnA' in pawn2['betza'])
+        self.assertFalse('ifmnD' in pawn2['betza'])
 
 
 if __name__ == '__main__':

--- a/tests/yarn_tests/variant_ini_parser.test.ts
+++ b/tests/yarn_tests/variant_ini_parser.test.ts
@@ -141,10 +141,10 @@ doubleStep = false
 
     const pawn1 = pieces.find(p => p.variant === 'withdoublestep' && p.name === 'Pawn');
     expect(pawn1).toBeDefined();
-    expect(pawn1?.betza).toContain('imfnA');
+    expect(pawn1?.betza).toContain('ifmnD');
 
     const pawn2 = pieces.find(p => p.variant === 'withoutdoublestep' && p.name === 'Pawn');
     expect(pawn2).toBeDefined();
-    expect(pawn2?.betza).not.toContain('imfnA');
+    expect(pawn2?.betza).not.toContain('ifmnD');
   });
 });

--- a/variant_ini_parser.py
+++ b/variant_ini_parser.py
@@ -110,8 +110,8 @@ class VariantIniParser:
 
         if props.get('double_step'):
             for piece in pieces:
-                if piece['name'].lower() == 'pawn' and 'imfnA' not in piece['betza']:
-                    piece['betza'] += 'imfnA'
+                if piece['name'].lower() == 'pawn' and 'ifmnD' not in piece['betza']:
+                    piece['betza'] += 'ifmnD'
 
         self.parsed_variants_cache[section_name] = (pieces, props)
         return pieces, props

--- a/variant_ini_parser.py
+++ b/variant_ini_parser.py
@@ -1,5 +1,5 @@
 import configparser
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Tuple
 
 class VariantIniParser:
     PREDEFINED_PIECES = {
@@ -11,19 +11,22 @@ class VariantIniParser:
         'v': ("Archbishop", "BN"), 'm': ("Chancellor", "RN")
     }
 
-    def __init__(self, ini_content: str, piece_catalog: List[Dict[str, Any]]):
+    def __init__(self, ini_content: str, piece_catalog: List[Dict[str, Any]], variant_properties: Dict[str, Any]):
         self.config = configparser.ConfigParser(interpolation=None, allow_no_value=True)
         self.config.optionxform = str
         cleaned_content = self._clean_ini_content(ini_content)
         self.config.read_string(cleaned_content)
 
         self.piece_catalog = piece_catalog
+        self.variant_properties = variant_properties
         self.catalog_by_variant = {}
         for piece in self.piece_catalog:
             variant = piece['variant']
             if variant not in self.catalog_by_variant:
                 self.catalog_by_variant[variant] = []
             self.catalog_by_variant[variant].append(piece)
+
+        self.parsed_variants_cache = {}
 
     def _clean_ini_content(self, ini_content: str) -> str:
         lines = ini_content.split('\n')
@@ -38,91 +41,85 @@ class VariantIniParser:
 
         return '\n'.join(lines[first_section_index:])
 
-    def _get_inherited_pieces(self, parent_variant_name: str) -> List[Dict[str, Any]]:
-        # Check if the parent is in the current INI file
-        for section in self.config.sections():
-            if section.split(':', 1)[0] == parent_variant_name:
-                # If it is, we need to parse it recursively
-                return self.parse_variant(section)
+    def parse_variant(self, section_name: str) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+        if section_name in self.parsed_variants_cache:
+            return self.parsed_variants_cache[section_name]
 
-        # If not, it must be a built-in variant from the catalog
-        return self.catalog_by_variant.get(parent_variant_name, [])
+        variant_name, _, parent_name = section_name.strip('[]').partition(':')
 
-    def parse_variant(self, section_name: str) -> List[Dict[str, Any]]:
-        variant_name, _, parent_name = section_name.replace(']', '').replace('[', '').partition(':')
+        parent_pieces = []
+        parent_props = {'double_step': False}
 
         if parent_name:
-            pieces = self._get_inherited_pieces(parent_name)
+            parent_section_found = False
+            for s in self.config.sections():
+                if s.strip('[]').split(':', 1)[0] == parent_name:
+                    parent_pieces, parent_props = self.parse_variant(s)
+                    parent_section_found = True
+                    break
+            if not parent_section_found:
+                parent_pieces = self.catalog_by_variant.get(parent_name, [])
+                parent_props = self.variant_properties.get(parent_name, {'double_step': False})
         else:
-            pieces = self.catalog_by_variant.get(variant_name, [])
+            parent_pieces = self.catalog_by_variant.get(variant_name, [])
+            parent_props = self.variant_properties.get(variant_name, {'double_step': False})
 
-        # Make a copy to avoid modifying the catalog
-        pieces = [p.copy() for p in pieces]
+        pieces = [p.copy() for p in parent_pieces]
         for p in pieces:
             p['variant'] = variant_name
+
+        props = parent_props.copy()
 
         if section_name in self.config:
             settings = self.config[section_name]
 
-            # Handle removals
+            if 'doubleStep' in settings:
+                props['double_step'] = settings['doubleStep'].lower() == 'true'
+
             removals = {k.lower().replace(' ', '') for k, v in settings.items() if v and v.strip() == '-'}
             pieces = [p for p in pieces if p['name'].lower().replace(' ', '') not in removals]
 
-            # Handle additions/modifications
             for key, value in settings.items():
-                if not value or value.strip() == '-' or key == "promotedPieceType":
+                if not value or value.strip() == '-' or key.lower() in ["promotedpiecetype", "doublestep"]:
                     continue
 
                 if ':' in value:
                     piece_char, betza = value.split(':', 1)
                     piece_name_key = key.lower().replace(' ', '')
-
                     is_custom = key.startswith('customPiece')
-                    if is_custom:
-                        piece_name = f"{variant_name.title()}-{piece_char}"
+                    piece_name = f"{variant_name.title()}-{piece_char}" if is_custom else key.title()
+
+                    found = any(p['name'].lower().replace(' ', '') == piece_name_key and 'betza' in p for p in pieces)
+                    if found:
+                        for piece in pieces:
+                            if piece['name'].lower().replace(' ', '') == piece_name_key:
+                                piece['betza'] = betza
                     else:
-                        piece_name = key.title()
-
-                    found = False
-                    for piece in pieces:
-                        if piece['name'].lower().replace(' ', '') == piece_name_key:
-                            piece['betza'] = betza
-                            found = True
-                            break
-
-                    if not found:
-                        pieces.append({
-                            "name": piece_name,
-                            "variant": variant_name,
-                            "betza": betza
-                        })
+                        pieces.append({"name": piece_name, "variant": variant_name, "betza": betza})
                 else:
-                    # Predefined piece
                     piece_char = value.strip()
                     if piece_char in self.PREDEFINED_PIECES:
                         official_name, betza = self.PREDEFINED_PIECES[piece_char]
-                        piece_name = official_name
+                        found = any(p['name'].lower().replace(' ', '') == official_name.lower() for p in pieces)
+                        if found:
+                            for piece in pieces:
+                                if piece['name'].lower().replace(' ', '') == official_name.lower():
+                                    piece['betza'] = betza
+                        else:
+                            pieces.append({"name": official_name, "variant": variant_name, "betza": betza})
 
-                        found = False
-                        for piece in pieces:
-                            if piece['name'].lower().replace(' ', '') == piece_name.lower().replace(' ', ''):
-                                piece['betza'] = betza
-                                found = True
-                                break
+        if props.get('double_step'):
+            for piece in pieces:
+                if piece['name'].lower() == 'pawn' and 'imfnA' not in piece['betza']:
+                    piece['betza'] += 'imfnA'
 
-                        if not found:
-                            pieces.append({
-                                "name": piece_name,
-                                "variant": variant_name,
-                                "betza": betza
-                            })
-
-        return pieces
+        self.parsed_variants_cache[section_name] = (pieces, props)
+        return pieces, props
 
     def parse(self) -> List[Dict[str, Any]]:
         all_pieces = []
         for section_name in self.config.sections():
-            pieces = self.parse_variant(section_name)
+            pieces, _ = self.parse_variant(section_name)
             all_pieces.extend(pieces)
 
         unique_pieces = []
@@ -133,4 +130,4 @@ class VariantIniParser:
                 unique_pieces.append(piece)
                 seen.add(identifier)
 
-        return unique_pieces[::-1]
+        return sorted(unique_pieces, key=lambda p: (p['variant'], p['name']))


### PR DESCRIPTION
…wn piece.

This commit addresses the issue where the initial double-step move for the standard chess pawn was missing from its Betza notation in variants inherited from Fairy-Stockfish's `chess_variant_base`.

The double-step capability is defined by a `doubleStep` boolean in the C++ source of Fairy-Stockfish, which defaults to `true` for `chess_variant_base` and its descendants but can be explicitly set to `false`.

This change introduces the following improvements:

1.  **Enhanced C++ Parser (`parse_cpp.py`):**
    - The parser now detects the `v->doubleStep = (true|false);` setting in the C++ source code.
    - It traverses the variant inheritance tree to determine the effective `doubleStep` status for each variant.
    - It generates a new `fsf_built_in_variant_properties.json` file to store this information, decoupling variant properties from the piece catalog.
    - The pawn's Betza string in the main catalog is now correctly appended with `"imfnA"` for variants where `doubleStep` is enabled.

2.  **Updated INI Parsers (`variant_ini_parser.py` and `src/variant_ini_parser.ts`):**
    - Both the Python and TypeScript INI parsers now load and utilize the new `fsf_built_in_variant_properties.json` file.
    - They support a `doubleStep` key in `.ini` files, allowing users to override the default behavior for custom variants.
    - The parsers correctly apply the `doubleStep` logic through the inheritance chain, ensuring consistent behavior between built-in and custom variants.

3.  **Build and Test Updates:**
    - The web app's build process has been updated to include the new properties file in the `dist` directory.
    - All relevant Python and TypeScript tests have been updated to reflect the changes and to verify the new functionality. A new test case was added to specifically validate the `doubleStep` logic.

These changes ensure that the pawn's movement is accurately represented across all supported chess variants, resolving the issue described in #69.